### PR TITLE
Preview support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dist
 build
 main.spec
 .env
+rustcode/
+.claude/
+CLAUDE.mdcache.json

--- a/announcement_dialog.py
+++ b/announcement_dialog.py
@@ -1,0 +1,97 @@
+from datetime import datetime, timezone
+
+from PySide6.QtCore import QThread, Signal
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QTextBrowser, QPushButton
+
+from github_api import fetch_repo_commits
+
+
+class AnnouncementWorker(QThread):
+    finished = Signal(list, str)  # (commits 列表, 错误信息)
+
+    def __init__(self, owner, repo, parent=None):
+        super().__init__(parent)
+        self.owner = owner
+        self.repo = repo
+        self._is_cancelled = False
+
+    def cancel(self):
+        self._is_cancelled = True
+
+    def run(self):
+        if self._is_cancelled:
+            return
+        commits, err = fetch_repo_commits(self.owner, self.repo, per_page=20)
+        if not self._is_cancelled:
+            self.finished.emit(commits, err)
+
+
+class AnnouncementDialog(QDialog):
+    def __init__(self, owner, repo, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("仓库更新公告")
+        self.resize(580, 480)
+
+        layout = QVBoxLayout()
+
+        title_label = QLabel("最近推送记录（最多 20 条）")
+        layout.addWidget(title_label)
+
+        self.browser = QTextBrowser()
+        self.browser.setHtml("<p>正在加载...</p>")
+        layout.addWidget(self.browser)
+
+        close_btn = QPushButton("关闭")
+        close_btn.clicked.connect(self.close)
+        layout.addWidget(close_btn)
+
+        self.setLayout(layout)
+
+        self.worker = AnnouncementWorker(owner, repo)
+        self.worker.finished.connect(self._on_loaded)
+        self.worker.start()
+        self._worker_running = True
+
+    def _on_loaded(self, commits, err):
+        self._worker_running = False
+        if err:
+            self.browser.setHtml(f"<p style='color:red;'>加载失败：{err}</p>")
+            return
+        if not commits:
+            self.browser.setHtml("<p>暂无提交记录。</p>")
+            return
+
+        parts = []
+        for c in commits:
+            commit_info = c.get("commit", {})
+            author_info = commit_info.get("author", {})
+            message = commit_info.get("message", "").strip()
+            author_name = author_info.get("name", "未知")
+            date_str = author_info.get("date", "")
+
+            # 将 UTC ISO 8601 转换为本地时间
+            try:
+                dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+                local_dt = dt.astimezone()
+                formatted_date = local_dt.strftime("%Y-%m-%d %H:%M")
+            except Exception:
+                formatted_date = date_str
+
+            # 多行 commit message 处理
+            message_html = message.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\n", "<br>")
+
+            parts.append(
+                f"<p>"
+                f"<b>{formatted_date}</b> &nbsp; {author_name}<br>"
+                f"{message_html}"
+                f"</p>"
+                f"<hr>"
+            )
+
+        self.browser.setHtml("".join(parts))
+
+    def closeEvent(self, event):
+        if hasattr(self, "worker") and self._worker_running:
+            self.worker.cancel()
+            self.worker.wait()
+        super().closeEvent(event)

--- a/announcement_dialog.py
+++ b/announcement_dialog.py
@@ -1,13 +1,14 @@
-from datetime import datetime, timezone
+from datetime import datetime
 
 from PySide6.QtCore import QThread, Signal
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QTextBrowser, QPushButton
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QTextBrowser, QPushButton
 
+import cache
 from github_api import fetch_repo_commits
 
 
 class AnnouncementWorker(QThread):
-    finished = Signal(list, str)  # (commits 列表, 错误信息)
+    finished = Signal(list, str)
 
     def __init__(self, owner, repo, parent=None):
         super().__init__(parent)
@@ -29,6 +30,8 @@ class AnnouncementWorker(QThread):
 class AnnouncementDialog(QDialog):
     def __init__(self, owner, repo, parent=None):
         super().__init__(parent)
+        self.owner = owner
+        self.repo = repo
         self.setWindowTitle("仓库更新公告")
         self.resize(580, 480)
 
@@ -38,29 +41,55 @@ class AnnouncementDialog(QDialog):
         layout.addWidget(title_label)
 
         self.browser = QTextBrowser()
-        self.browser.setHtml("<p>正在加载...</p>")
         layout.addWidget(self.browser)
 
+        btn_row = QHBoxLayout()
+        self.refresh_btn = QPushButton("刷新")
+        self.refresh_btn.clicked.connect(self._start_load)
         close_btn = QPushButton("关闭")
         close_btn.clicked.connect(self.close)
-        layout.addWidget(close_btn)
+        btn_row.addWidget(self.refresh_btn)
+        btn_row.addStretch()
+        btn_row.addWidget(close_btn)
+        layout.addLayout(btn_row)
 
         self.setLayout(layout)
+        self._worker = None
+        self._worker_running = False
 
-        self.worker = AnnouncementWorker(owner, repo)
-        self.worker.finished.connect(self._on_loaded)
-        self.worker.start()
+        # 先显示缓存
+        cached = cache.get_commits()
+        if cached:
+            self._render(cached)
+            self.refresh_btn.setText("刷新")
+        else:
+            self.browser.setHtml("<p>正在加载...</p>")
+            self._start_load()
+
+    def _start_load(self):
+        if self._worker_running:
+            return
+        self.refresh_btn.setEnabled(False)
+        self.refresh_btn.setText("正在刷新...")
+        self._worker = AnnouncementWorker(self.owner, self.repo)
+        self._worker.finished.connect(self._on_loaded)
+        self._worker.start()
         self._worker_running = True
 
     def _on_loaded(self, commits, err):
         self._worker_running = False
+        self.refresh_btn.setEnabled(True)
+        self.refresh_btn.setText("刷新")
         if err:
             self.browser.setHtml(f"<p style='color:red;'>加载失败：{err}</p>")
             return
         if not commits:
             self.browser.setHtml("<p>暂无提交记录。</p>")
             return
+        cache.set_commits(commits)
+        self._render(commits)
 
+    def _render(self, commits):
         parts = []
         for c in commits:
             commit_info = c.get("commit", {})
@@ -68,30 +97,23 @@ class AnnouncementDialog(QDialog):
             message = commit_info.get("message", "").strip()
             author_name = author_info.get("name", "未知")
             date_str = author_info.get("date", "")
-
-            # 将 UTC ISO 8601 转换为本地时间
             try:
                 dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
-                local_dt = dt.astimezone()
-                formatted_date = local_dt.strftime("%Y-%m-%d %H:%M")
+                formatted_date = dt.astimezone().strftime("%Y-%m-%d %H:%M")
             except Exception:
                 formatted_date = date_str
-
-            # 多行 commit message 处理
-            message_html = message.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\n", "<br>")
-
+            message_html = (message
+                            .replace("&", "&amp;")
+                            .replace("<", "&lt;")
+                            .replace(">", "&gt;")
+                            .replace("\n", "<br>"))
             parts.append(
-                f"<p>"
-                f"<b>{formatted_date}</b> &nbsp; {author_name}<br>"
-                f"{message_html}"
-                f"</p>"
-                f"<hr>"
+                f"<p><b>{formatted_date}</b> &nbsp; {author_name}<br>{message_html}</p><hr>"
             )
-
         self.browser.setHtml("".join(parts))
 
     def closeEvent(self, event):
-        if hasattr(self, "worker") and self._worker_running:
-            self.worker.cancel()
-            self.worker.wait()
+        if self._worker and self._worker_running:
+            self._worker.cancel()
+            self._worker.wait()
         super().closeEvent(event)

--- a/cache.py
+++ b/cache.py
@@ -1,0 +1,67 @@
+# cache.py — 持久化缓存，保存在 cache.json
+import json
+import os
+
+_CACHE_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "cache.json")
+
+_data = {
+    "file_lists": {},   # folder_name -> [file entry, ...]
+    "timestamps": {},   # file_path   -> date_str | "__rate_limit__"
+    "commits": [],      # commit list (raw GitHub API dicts)
+}
+
+
+def load():
+    global _data
+    if os.path.exists(_CACHE_FILE):
+        try:
+            with open(_CACHE_FILE, "r", encoding="utf-8") as f:
+                loaded = json.load(f)
+            # 合并，兼容旧版缓存文件缺字段的情况
+            for key in _data:
+                if key in loaded:
+                    _data[key] = loaded[key]
+        except Exception as e:
+            print(f"缓存加载失败: {e}")
+
+
+def _save():
+    try:
+        with open(_CACHE_FILE, "w", encoding="utf-8") as f:
+            json.dump(_data, f, ensure_ascii=False, indent=2)
+    except Exception as e:
+        print(f"缓存保存失败: {e}")
+
+
+# ── 文件列表 ──────────────────────────────────────────────
+def get_file_list(folder):
+    return _data["file_lists"].get(folder)
+
+
+def set_file_list(folder, files):
+    _data["file_lists"][folder] = files
+    _save()
+
+
+# ── 上传时间 ──────────────────────────────────────────────
+def get_all_timestamps():
+    return _data["timestamps"]
+
+
+def get_timestamp(file_path):
+    return _data["timestamps"].get(file_path)
+
+
+def set_timestamp(file_path, date_str):
+    _data["timestamps"][file_path] = date_str
+    _save()
+
+
+# ── 仓库 commit 公告 ──────────────────────────────────────
+def get_commits():
+    return _data["commits"] if _data["commits"] else None
+
+
+def set_commits(commits):
+    _data["commits"] = commits
+    _save()

--- a/download_thread.py
+++ b/download_thread.py
@@ -1,18 +1,19 @@
-from PyQt5.QtCore import QThread, pyqtSignal
+from PySide6.QtCore import QThread, Signal
 import requests
 import os
 
-class DownloadThread(QThread):
-    progress = pyqtSignal(int)
-    finished = pyqtSignal(bool, str)
 
-    def __init__(self, url, save_path, mirror="ghproxy"):
+class DownloadThread(QThread):
+    progress = Signal(int)
+    finished = Signal(bool, str)
+
+    def __init__(self, url, save_path, mirror="raw"):
         super().__init__()
         self.url = url
         self.save_path = save_path
         self.mirror = mirror
         self._is_running = True
-        self.mirrors = ["ghproxy", "jsdelivr", "tbedu", "raw"]
+        self.mirrors = ["raw", "jsdelivr", "ghproxy.net", "ghfast.top"]
 
     def stop(self):
         self._is_running = False
@@ -31,7 +32,7 @@ class DownloadThread(QThread):
                     with open(self.save_path, 'wb') as f:
                         for chunk in r.iter_content(chunk_size=8192):
                             if not self._is_running:
-                                self.finished.emit(False, "❌ 下载已取消")
+                                self.finished.emit(False, "下载已取消")
                                 return
                             if chunk:
                                 f.write(chunk)
@@ -39,20 +40,20 @@ class DownloadThread(QThread):
                                 if total_size:
                                     percent = int(downloaded * 100 / total_size)
                                     self.progress.emit(percent)
-                    self.finished.emit(True, f"✅ 下载完成 (via {current_mirror}): {self.save_path}")
+                    self.finished.emit(True, f"下载完成 (via {current_mirror}): {self.save_path}")
                     return
-            except Exception as e:
-                continue  # 继续尝试下一个镜像
+            except Exception:
+                continue
 
-        self.finished.emit(False, f"❌ 所有镜像均下载失败（尝试过：{', '.join(tried)}）")
+        self.finished.emit(False, f"所有镜像均下载失败（尝试过：{', '.join(tried)}）")
 
     def convert_to_mirror(self, url, mirror):
-        if mirror == "ghproxy":
-            return f"https://ghproxy.com/{url}"
+        if mirror == "ghproxy.net":
+            return f"https://ghproxy.net/{url}"
+        elif mirror == "ghfast.top":
+            return f"https://ghfast.top/{url}"
         elif mirror == "jsdelivr":
             return url.replace("https://raw.githubusercontent.com/", "https://cdn.jsdelivr.net/gh/").replace("/main/", "@main/")
-        elif mirror == "tbedu":
-            return f"https://github.tbedu.top/{url}"
         elif mirror == "raw":
             return url
         return url

--- a/downloader.py
+++ b/downloader.py
@@ -1,9 +1,11 @@
 import requests
 import os
 
-def convert_to_mirror(url: str, mirror="ghproxy") -> str:
-    if mirror == "ghproxy":
-        return f"https://ghproxy.com/{url}"
+def convert_to_mirror(url: str, mirror="raw") -> str:
+    if mirror == "ghproxy.net":
+        return f"https://ghproxy.net/{url}"
+    elif mirror == "ghfast.top":
+        return f"https://ghfast.top/{url}"
     elif mirror == "jsdelivr":
         # 转换 raw.githubusercontent 链接为 jsDelivr 格式
         # 示例：raw.githubusercontent.com/user/repo/main/path → cdn.jsdelivr.net/gh/user/repo@main/path
@@ -12,7 +14,7 @@ def convert_to_mirror(url: str, mirror="ghproxy") -> str:
             "https://cdn.jsdelivr.net/gh/"
         ).replace("/main/", "@main/")
     else:
-        return url  # 默认不修改
+        return url  # raw 或未知：不修改
 
 def download_file(url, save_path, mirror="ghproxy"):
     real_url = convert_to_mirror(url, mirror)
@@ -22,13 +24,13 @@ def download_file(url, save_path, mirror="ghproxy"):
         r.raise_for_status()
         with open(save_path, "wb") as f:
             f.write(r.content)
-        print(f"✅ 下载完成: {save_path}")
+        print(f"下载完成: {save_path}")
     except Exception as e:
-        print(f"❌ 下载失败: {save_path}，错误信息: {e}")
+        print(f"下载失败: {save_path}，错误信息: {e}")
 
 
-def download_file_with_progress(url, save_path, mirror="ghproxy", progress_callback=None):
-    mirrors = ["ghproxy", "jsdelivr", "raw"]
+def download_file_with_progress(url, save_path, mirror="raw", progress_callback=None):
+    mirrors = ["raw", "jsdelivr", "ghproxy.net", "ghfast.top"]
     tried = []
 
     for current_mirror in [mirror] + [m for m in mirrors if m != mirror]:

--- a/github_api.py
+++ b/github_api.py
@@ -15,8 +15,9 @@ def list_github_contents(owner, repo, path=""):
         r.raise_for_status()
         return r.json()
     except requests.exceptions.RequestException as e:
-        print("❌ 网络连接失败：", e)
+        print("网络连接失败：", e)
         return []
+
 def list_all_files_recursive(owner, repo, path=""):
     files = []
     try:
@@ -27,9 +28,36 @@ def list_all_files_recursive(owner, repo, path=""):
             elif item["type"] == "dir":
                 files.extend(list_all_files_recursive(owner, repo, item["path"]))
     except Exception as e:
-        print(f"❌ 加载 {path} 失败: {e}")
+        print(f"加载 {path} 失败: {e}")
     return files
 
 def list_folders_only(owner, repo, path=""):
     items = list_github_contents(owner, repo, path)
     return [item for item in items if item["type"] == "dir"]
+
+def fetch_repo_commits(owner, repo, per_page=20):
+    """获取仓库最近的 commit 列表"""
+    url = f"https://api.github.com/repos/{owner}/{repo}/commits?per_page={per_page}"
+    try:
+        r = requests.get(url, headers=HEADERS, timeout=10)
+        r.raise_for_status()
+        return r.json(), ""
+    except requests.exceptions.HTTPError as e:
+        return [], f"HTTP 错误: {e}"
+    except requests.exceptions.RequestException as e:
+        return [], f"网络连接失败: {e}"
+
+def fetch_file_last_commit(owner, repo, file_path):
+    """获取指定文件最后一次 commit 信息"""
+    url = f"https://api.github.com/repos/{owner}/{repo}/commits?path={file_path}&per_page=1"
+    try:
+        r = requests.get(url, headers=HEADERS, timeout=10)
+        if r.status_code == 403:
+            return None, "rate_limit"
+        r.raise_for_status()
+        data = r.json()
+        if data:
+            return data[0], ""
+        return None, ""
+    except requests.exceptions.RequestException as e:
+        return None, f"网络连接失败: {e}"

--- a/github_hosts_updater.py
+++ b/github_hosts_updater.py
@@ -27,9 +27,9 @@ def update_hosts(domain_ip_map):
                 content += f"\n{ip} {domain} # github加速\n"
             f.write(content)
             f.truncate()
-        print("✅ hosts 更新完成")
+        print("hosts 更新完成")
     except Exception as e:
-        print(f"❌ 写入 hosts 失败: {e}")
+        print(f"写入 hosts 失败: {e}")
 
 def update_github_hosts():
     domain_ip_map = {}

--- a/mirror_dialog.py
+++ b/mirror_dialog.py
@@ -1,18 +1,28 @@
 # mirror_dialog.py
-from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QComboBox, QPushButton
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QComboBox, QPushButton
+
+
+MIRRORS = [
+    ("raw（直连 GitHub，实时但国内不稳定）", "raw"),
+    ("jsdelivr（CDN 加速，国内稳定，有缓存延迟）", "jsdelivr"),
+    ("ghproxy.net（代理加速，支持大文件）", "ghproxy.net"),
+    ("ghfast.top（代理加速，备用）", "ghfast.top"),
+]
+
 
 class MirrorSelectDialog(QDialog):
     def __init__(self):
         super().__init__()
         self.setWindowTitle("选择默认镜像源")
-        self.setFixedWidth(400)
+        self.setFixedWidth(460)
 
         layout = QVBoxLayout()
         layout.addWidget(QLabel("请选择一个默认镜像源："))
 
         self.mirror_box = QComboBox()
-        self.mirror_box.addItems(["ghproxy", "jsdelivr", "tbedu", "raw"])
-        self.mirror_box.setCurrentText("jsdelivr")
+        for label, key in MIRRORS:
+            self.mirror_box.addItem(label, key)
+        self.mirror_box.setCurrentIndex(0)  # 默认 raw
         layout.addWidget(self.mirror_box)
 
         confirm_btn = QPushButton("确定")
@@ -22,4 +32,4 @@ class MirrorSelectDialog(QDialog):
         self.setLayout(layout)
 
     def get_selected_mirror(self):
-        return self.mirror_box.currentText()
+        return self.mirror_box.currentData()

--- a/preview_worker.py
+++ b/preview_worker.py
@@ -1,7 +1,7 @@
 import os
-from PyQt5.QtCore import QThread, pyqtSignal, Qt
-from PyQt5.QtGui import QPixmap
-from PyQt5.QtWidgets import QDialog, QLabel, QVBoxLayout
+from PySide6.QtCore import QThread, Signal, Qt
+from PySide6.QtGui import QPixmap
+from PySide6.QtWidgets import QDialog, QLabel, QVBoxLayout
 
 try:
     import requests
@@ -12,12 +12,12 @@ except Exception:
 
 
 class PreviewWorker(QThread):
-    finished = pyqtSignal(QPixmap, str)  # pixmap, 错误信息(为空则成功)
+    finished = Signal(QPixmap, str)  # pixmap, 错误信息(为空则成功)
 
     def __init__(self, url: str, parent=None):
         super().__init__(parent)
         self.url = url
-        self._is_cancelled = False   # ✅ 新增：取消标志
+        self._is_cancelled = False
 
     def cancel(self):
         """通知线程尽快停止"""
@@ -25,7 +25,6 @@ class PreviewWorker(QThread):
 
     def run(self):
         try:
-            # 如果已经取消，直接返回
             if self._is_cancelled:
                 return
 
@@ -33,7 +32,6 @@ class PreviewWorker(QThread):
                 resp = requests.get(self.url, timeout=12, stream=True)
                 resp.raise_for_status()
 
-                # 边下载边检查取消
                 data = b""
                 for chunk in resp.iter_content(1024):
                     if self._is_cancelled:
@@ -55,12 +53,12 @@ class PreviewWorker(QThread):
 
             pm = QPixmap()
             if not pm.loadFromData(data):
-                self.finished.emit(QPixmap(), "❌ 图片解码失败")
+                self.finished.emit(QPixmap(), "图片解码失败")
             else:
                 self.finished.emit(pm, "")
         except Exception as e:
-            if not self._is_cancelled:  # 被取消时不发信号
-                self.finished.emit(QPixmap(), f"⚠️ 下载失败: {e}")
+            if not self._is_cancelled:
+                self.finished.emit(QPixmap(), f"下载失败: {e}")
 
 
 class PreviewDialog(QDialog):
@@ -69,14 +67,13 @@ class PreviewDialog(QDialog):
         self.setWindowTitle("图片预览")
         self.resize(640, 480)
 
-        self.label = QLabel("⏳ 正在加载...", self)
+        self.label = QLabel("正在加载...", self)
         self.label.setAlignment(Qt.AlignCenter)
 
         layout = QVBoxLayout()
         layout.addWidget(self.label)
         self.setLayout(layout)
 
-        # 开启线程加载
         self.worker = PreviewWorker(url)
         self.worker.finished.connect(self.on_finished)
         self.worker.start()
@@ -94,7 +91,6 @@ class PreviewDialog(QDialog):
             self.label.setPixmap(scaled)
 
     def closeEvent(self, event):
-        # 关闭时取消后台线程
         if hasattr(self, "worker") and self._worker_running:
             self.worker.cancel()
             self.worker.wait()

--- a/ui_main.py
+++ b/ui_main.py
@@ -19,6 +19,20 @@ from github_hosts_updater import update_github_hosts
 from preview_worker import PreviewDialog
 from mirror_dialog import MIRRORS
 
+
+class FolderLoaderWorker(QThread):
+    finished = Signal(list)  # 文件列表
+
+    def __init__(self, owner, repo, folder_name, parent=None):
+        super().__init__(parent)
+        self.owner = owner
+        self.repo = repo
+        self.folder_name = folder_name
+
+    def run(self):
+        files = list_all_files_recursive(self.owner, self.repo, self.folder_name)
+        self.finished.emit([f for f in files if f["type"] == "file"])
+
 OWNER = "KonshinHaoshin"
 REPO = "mygoxmujica_archive"
 
@@ -141,12 +155,15 @@ class MainWindow(QMainWindow):
 
         self._timestamp_cache = {}
         self._timestamp_worker = None
+        self._folder_loader = None
 
         layout = QVBoxLayout()
         layout.addWidget(QLabel("选择目录："))
         layout.addWidget(self.folder_box)
-        layout.addWidget(self.announcement_button)
-        layout.addWidget(self.load_button)
+        top_btn_row = QHBoxLayout()
+        top_btn_row.addWidget(self.load_button, 1)
+        top_btn_row.addWidget(self.announcement_button, 1)
+        layout.addLayout(top_btn_row)
         layout.addWidget(self.search_bar)
         layout.addWidget(self.list_widget)
         layout.addWidget(self.update_hosts_button)
@@ -272,10 +289,9 @@ class MainWindow(QMainWindow):
             self._start_timestamp_worker(file_path)
 
     def _start_timestamp_worker(self, file_path):
-        # 取消上一个未完成的请求
         if self._timestamp_worker is not None and self._timestamp_worker.isRunning():
             self._timestamp_worker.cancel()
-            self._timestamp_worker.wait()
+            # 不阻塞等待，让旧线程自行结束
 
         self._timestamp_worker = TimestampWorker(file_path)
         self._timestamp_worker.finished.connect(self.on_timestamp_loaded)
@@ -299,10 +315,20 @@ class MainWindow(QMainWindow):
 
     def load_selected_folder_files(self):
         folder_name = self.folder_box.currentText()
+        if not folder_name:
+            return
         self._timestamp_cache.clear()
-        files = list_all_files_recursive(OWNER, REPO, folder_name)
-        self.entries = [f for f in files if f["type"] == "file"]
-        self.update_list_widget(self.entries)
+        self.load_button.setEnabled(False)
+        self.status_label.setText("正在加载目录内容...")
+
+        self._folder_loader = FolderLoaderWorker(OWNER, REPO, folder_name)
+        self._folder_loader.finished.connect(self._on_folder_loaded)
+        self._folder_loader.start()
+
+    def _on_folder_loaded(self, files):
+        self.load_button.setEnabled(True)
+        self.entries = files
+        self.update_list_widget(files)
 
     def update_list_widget(self, entries):
         self.list_widget.setUpdatesEnabled(False)

--- a/ui_main.py
+++ b/ui_main.py
@@ -82,7 +82,7 @@ def extract_archive(file_path, extract_to):
 
 
 class TimestampWorker(QThread):
-    finished = Signal(str, str)  # (file_path, 日期字符串或空)
+    result = Signal(str, str)  # (file_path, 日期字符串或空)
 
     def __init__(self, file_path, parent=None):
         super().__init__(parent)
@@ -99,7 +99,7 @@ class TimestampWorker(QThread):
         if self._is_cancelled:
             return
         if err == "rate_limit":
-            self.finished.emit(self.file_path, "__rate_limit__")
+            self.result.emit(self.file_path, "__rate_limit__")
             return
         if commit:
             try:
@@ -107,11 +107,11 @@ class TimestampWorker(QThread):
                 dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
                 local_dt = dt.astimezone()
                 formatted = local_dt.strftime("%Y-%m-%d %H:%M")
-                self.finished.emit(self.file_path, formatted)
+                self.result.emit(self.file_path, formatted)
                 return
             except Exception:
                 pass
-        self.finished.emit(self.file_path, "")
+        self.result.emit(self.file_path, "")
 
 
 class MainWindow(QMainWindow):
@@ -155,6 +155,7 @@ class MainWindow(QMainWindow):
 
         self._timestamp_cache = {}
         self._timestamp_worker = None
+        self._pending_workers = []  # 保持引用直到线程真正结束
         self._folder_loader = None
 
         layout = QVBoxLayout()
@@ -289,13 +290,18 @@ class MainWindow(QMainWindow):
             self._start_timestamp_worker(file_path)
 
     def _start_timestamp_worker(self, file_path):
-        if self._timestamp_worker is not None and self._timestamp_worker.isRunning():
-            self._timestamp_worker.cancel()
-            # 不阻塞等待，让旧线程自行结束
+        # 取消所有仍在运行的旧请求
+        for w in self._pending_workers:
+            if w.isRunning():
+                w.cancel()
 
-        self._timestamp_worker = TimestampWorker(file_path)
-        self._timestamp_worker.finished.connect(self.on_timestamp_loaded)
-        self._timestamp_worker.start()
+        worker = TimestampWorker(file_path)
+        worker.result.connect(self.on_timestamp_loaded)
+        # 线程结束后从列表移除，释放引用
+        worker.finished.connect(lambda: self._pending_workers.remove(worker))
+        self._pending_workers.append(worker)
+        self._timestamp_worker = worker
+        worker.start()
 
     def on_timestamp_loaded(self, file_path, date_str):
         self._timestamp_cache[file_path] = date_str

--- a/ui_main.py
+++ b/ui_main.py
@@ -18,6 +18,7 @@ from github_api import list_all_files_recursive, list_folders_only, fetch_file_l
 from github_hosts_updater import update_github_hosts
 from preview_worker import PreviewDialog
 from mirror_dialog import MIRRORS
+import cache
 
 
 class FolderLoaderWorker(QThread):
@@ -153,7 +154,8 @@ class MainWindow(QMainWindow):
         self.status_label = QLabel("")
         self.status_label.setWordWrap(True)
 
-        self._timestamp_cache = {}
+        cache.load()
+        self._timestamp_cache = cache.get_all_timestamps()  # 直接引用持久化缓存字典
         self._timestamp_worker = None
         self._pending_workers = []  # 保持引用直到线程真正结束
         self._folder_loader = None
@@ -305,6 +307,7 @@ class MainWindow(QMainWindow):
 
     def on_timestamp_loaded(self, file_path, date_str):
         self._timestamp_cache[file_path] = date_str
+        cache.set_timestamp(file_path, date_str)
 
         # 只在当前选中文件匹配时更新 UI
         idx = self.list_widget.currentRow()
@@ -323,16 +326,25 @@ class MainWindow(QMainWindow):
         folder_name = self.folder_box.currentText()
         if not folder_name:
             return
-        self._timestamp_cache.clear()
+
+        # 有缓存先立即显示
+        cached = cache.get_file_list(folder_name)
+        if cached:
+            self.entries = cached
+            self.update_list_widget(cached)
+
+        # 始终在后台刷新
         self.load_button.setEnabled(False)
-        self.status_label.setText("正在加载目录内容...")
+        if not cached:
+            self.status_label.setText("正在加载目录内容...")
 
         self._folder_loader = FolderLoaderWorker(OWNER, REPO, folder_name)
-        self._folder_loader.finished.connect(self._on_folder_loaded)
+        self._folder_loader.finished.connect(lambda files: self._on_folder_loaded(folder_name, files))
         self._folder_loader.start()
 
-    def _on_folder_loaded(self, files):
+    def _on_folder_loaded(self, folder_name, files):
         self.load_button.setEnabled(True)
+        cache.set_file_list(folder_name, files)
         self.entries = files
         self.update_list_widget(files)
 

--- a/ui_main.py
+++ b/ui_main.py
@@ -2,20 +2,25 @@
 import os
 import sys
 import subprocess
+from datetime import datetime
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import (
+from PySide6.QtCore import Qt, QThread, Signal
+from PySide6.QtGui import QIcon
+from PySide6.QtWidgets import (
     QMainWindow, QPushButton, QListWidget, QVBoxLayout, QWidget,
     QFileDialog, QComboBox, QLabel, QLineEdit, QProgressBar,
     QMessageBox, QCheckBox, QHBoxLayout
 )
 
+from announcement_dialog import AnnouncementDialog
 from download_thread import DownloadThread
-from github_api import list_all_files_recursive, list_folders_only
-from downloader import download_file, download_file_with_progress
+from github_api import list_all_files_recursive, list_folders_only, fetch_file_last_commit
 from github_hosts_updater import update_github_hosts
-from preview_worker import PreviewDialog  # 新增导入
+from preview_worker import PreviewDialog
+from mirror_dialog import MIRRORS
+
+OWNER = "KonshinHaoshin"
+REPO = "mygoxmujica_archive"
 
 
 def resource_path(relative_path):
@@ -45,21 +50,54 @@ def is_supported_archive(filename):
 def extract_archive(file_path, extract_to):
     exe_path = resource_path("7-Zip/7z.exe")
     if not os.path.exists(exe_path):
-        print("❌ 找不到 7z.exe，请确认路径正确")
+        print("找不到 7z.exe，请确认路径正确")
         return False
 
     cmd = [exe_path, "x", file_path, f"-o{extract_to}", "-y"]
     try:
         result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
         if result.returncode == 0:
-            print("✅ 使用 7-Zip 解压成功")
+            print("使用 7-Zip 解压成功")
             return True
         else:
-            print("❌ 7-Zip 解压失败：", result.stderr)
+            print("7-Zip 解压失败：", result.stderr)
             return False
     except Exception as e:
-        print("❌ 解压过程中出现异常：", e)
+        print("解压过程中出现异常：", e)
         return False
+
+
+class TimestampWorker(QThread):
+    finished = Signal(str, str)  # (file_path, 日期字符串或空)
+
+    def __init__(self, file_path, parent=None):
+        super().__init__(parent)
+        self.file_path = file_path
+        self._is_cancelled = False
+
+    def cancel(self):
+        self._is_cancelled = True
+
+    def run(self):
+        if self._is_cancelled:
+            return
+        commit, err = fetch_file_last_commit(OWNER, REPO, self.file_path)
+        if self._is_cancelled:
+            return
+        if err == "rate_limit":
+            self.finished.emit(self.file_path, "__rate_limit__")
+            return
+        if commit:
+            try:
+                date_str = commit["commit"]["author"]["date"]
+                dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+                local_dt = dt.astimezone()
+                formatted = local_dt.strftime("%Y-%m-%d %H:%M")
+                self.finished.emit(self.file_path, formatted)
+                return
+            except Exception:
+                pass
+        self.finished.emit(self.file_path, "")
 
 
 class MainWindow(QMainWindow):
@@ -72,34 +110,42 @@ class MainWindow(QMainWindow):
         self.setWindowIcon(QIcon(resource_path("icon.png")))
         self.setWindowTitle("mygoxmujica社区资源下载器 关注B站东山燃灯寺谢谢喵~")
 
-        # 控件
         self.folder_box = QComboBox()
         self.search_bar = QLineEdit()
-        self.search_bar.setPlaceholderText("🔍 输入关键字以筛选")
+        self.search_bar.setPlaceholderText("输入关键字以筛选")
         self.list_widget = QListWidget()
         self.load_button = QPushButton("加载选中目录内容")
         self.download_button = QPushButton("下载选中项")
-        self.preview_button = QPushButton("预览图片")  # 新增按钮
-        self.stop_button = QPushButton("🛑 停止下载")
+        self.preview_button = QPushButton("预览图片")
+        self.stop_button = QPushButton("停止下载")
         self.stop_button.setEnabled(True)
         self.stop_button.clicked.connect(self.stop_download)
 
         self.mirror_box = QComboBox()
-        self.mirror_box.addItems(["jsdelivr", "raw", "ghproxy", "tbedu"])
-        self.mirror_box.setCurrentText(default_mirror)
+        for label, key in MIRRORS:
+            self.mirror_box.addItem(label, key)
+        self.mirror_box.setCurrentIndex(
+            next((i for i, (_, k) in enumerate(MIRRORS) if k == default_mirror), 0)
+        )
         self.list_widget.currentRowChanged.connect(self.update_file_info)
         self.last_save_dir = os.getcwd()
 
-        self.update_hosts_button = QPushButton("💻 更新 GitHub Hosts（需要管理员权限）")
+        self.update_hosts_button = QPushButton("更新 GitHub Hosts（需要管理员权限）")
         self.update_hosts_button.clicked.connect(self.update_github_hosts_action)
+
+        self.announcement_button = QPushButton("查看仓库更新公告")
+        self.announcement_button.clicked.connect(self.show_announcement)
 
         self.status_label = QLabel("")
         self.status_label.setWordWrap(True)
 
-        # 布局
+        self._timestamp_cache = {}
+        self._timestamp_worker = None
+
         layout = QVBoxLayout()
         layout.addWidget(QLabel("选择目录："))
         layout.addWidget(self.folder_box)
+        layout.addWidget(self.announcement_button)
         layout.addWidget(self.load_button)
         layout.addWidget(self.search_bar)
         layout.addWidget(self.list_widget)
@@ -113,10 +159,10 @@ class MainWindow(QMainWindow):
 
         self.mirror_label = QLabel("选择镜像源：")
         self.mirror_desc = QLabel("""
-        🔹 jsdelivr：✅ 国内高速稳定，适合小/中级文件，仅对更新有缓存延迟  
-        🔹 raw：直连 GitHub，实时源码，适合调试，但国内不稳定  
-        🔹 ghproxy：备用方案，但已不可靠，易超时或无响应  
-        🔹 tbedu：📦 新增！tbedu 直链镜像，适合 raw.githubusercontent 文件加速
+        raw：直连 GitHub，实时源码，国内可能不稳定
+        jsdelivr：CDN 加速，国内稳定，适合小/中型文件，有缓存延迟
+        ghproxy.net：代理加速，支持大文件，国内可用
+        ghfast.top：代理加速，备用方案
         """)
         self.mirror_desc.setWordWrap(True)
 
@@ -128,7 +174,7 @@ class MainWindow(QMainWindow):
         self.auto_extract_checkbox.setChecked(True)
         layout.addWidget(self.auto_extract_checkbox)
 
-        layout.addWidget(QLabel("⬇ 当前状态："))
+        layout.addWidget(QLabel("当前状态："))
         layout.addWidget(self.status_label)
 
         self.progress_bar = QProgressBar()
@@ -140,16 +186,18 @@ class MainWindow(QMainWindow):
         container.setLayout(layout)
         self.setCentralWidget(container)
 
-        # 信号连接
         self.load_button.clicked.connect(self.load_selected_folder_files)
         self.download_button.clicked.connect(self.download_selected)
         self.search_bar.textChanged.connect(self.filter_list)
-        self.preview_button.clicked.connect(self.preview_selected)  # 绑定预览
+        self.preview_button.clicked.connect(self.preview_selected)
 
-        # 初始化
         self.entries = []
         self.filtered_entries = []
         self.load_root_folders()
+
+    def show_announcement(self):
+        dlg = AnnouncementDialog(OWNER, REPO, self)
+        dlg.exec()
 
     def preview_selected(self):
         idx = self.list_widget.currentRow()
@@ -163,38 +211,35 @@ class MainWindow(QMainWindow):
             QMessageBox.warning(self, "提示", "选中的不是图片文件")
             return
 
-        # 根据镜像源拼 URL
-        mirror = self.mirror_box.currentText()
-        owner, repo, branch = "KonshinHaoshin", "mygoxmujica_archive", "main"
+        mirror = self.mirror_box.currentData()
+        owner, repo, branch = OWNER, REPO, "main"
         rel_path = entry["path"].lstrip("/")
-        raw_url = entry.get("download_url") or \
-                  f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{rel_path}"
+        raw_url = entry.get("download_url") or f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{rel_path}"
 
         if mirror == "raw":
             url = raw_url
-        elif mirror == "ghproxy":
+        elif mirror == "ghproxy.net":
             url = f"https://ghproxy.net/{raw_url}"
-        elif mirror == "tbedu":
-            url = f"https://mirror.ghproxy.com/{raw_url}"
+        elif mirror == "ghfast.top":
+            url = f"https://ghfast.top/{raw_url}"
         elif mirror == "jsdelivr":
             url = f"https://cdn.jsdelivr.net/gh/{owner}/{repo}@{branch}/{rel_path}"
         else:
             url = raw_url
 
         dlg = PreviewDialog(url, self)
-        dlg.exec_()
+        dlg.exec()
 
     def update_github_hosts_action(self):
         try:
             update_github_hosts()
-            QMessageBox.information(self, "Hosts 更新", "✅ GitHub hosts 已更新完成，请刷新网络生效。")
+            QMessageBox.information(self, "Hosts 更新", "GitHub hosts 已更新完成，请刷新网络生效。")
         except Exception as e:
-            QMessageBox.critical(self, "Hosts 更新失败", f"❌ 更新失败：{str(e)}\n请尝试以管理员身份运行本程序。")
-
+            QMessageBox.critical(self, "Hosts 更新失败", f"更新失败：{str(e)}\n请尝试以管理员身份运行本程序。")
 
     def update_file_info(self, index):
         if index < 0 or index >= len(self.filtered_entries):
-            self.status_label.setText("📂 未选择任何文件")
+            self.status_label.setText("未选择任何文件")
             return
 
         entry = self.filtered_entries[index]
@@ -208,33 +253,67 @@ class MainWindow(QMainWindow):
                 size_str = f"{size_bytes / 1024:.1f} KB"
             else:
                 size_str = f"{size_bytes / (1024 * 1024):.2f} MB"
-            self.status_label.setText(f"📁 选中: {name} (大小：{size_str})")
+            base_info = f"选中: {name} （大小：{size_str}）"
         else:
-            self.status_label.setText(f"📁 选中: {name} (大小未知)")
+            base_info = f"选中: {name} （大小未知）"
+
+        file_path = entry["path"]
+
+        if file_path in self._timestamp_cache:
+            cached = self._timestamp_cache[file_path]
+            if cached == "__rate_limit__":
+                self.status_label.setText(f"{base_info}\n上传时间：获取失败（API 频率限制，建议配置 GITHUB_TOKEN）")
+            elif cached:
+                self.status_label.setText(f"{base_info}\n上传时间：{cached}")
+            else:
+                self.status_label.setText(f"{base_info}\n上传时间：获取失败")
+        else:
+            self.status_label.setText(f"{base_info}\n正在获取上传时间...")
+            self._start_timestamp_worker(file_path)
+
+    def _start_timestamp_worker(self, file_path):
+        # 取消上一个未完成的请求
+        if self._timestamp_worker is not None and self._timestamp_worker.isRunning():
+            self._timestamp_worker.cancel()
+            self._timestamp_worker.wait()
+
+        self._timestamp_worker = TimestampWorker(file_path)
+        self._timestamp_worker.finished.connect(self.on_timestamp_loaded)
+        self._timestamp_worker.start()
+
+    def on_timestamp_loaded(self, file_path, date_str):
+        self._timestamp_cache[file_path] = date_str
+
+        # 只在当前选中文件匹配时更新 UI
+        idx = self.list_widget.currentRow()
+        if 0 <= idx < len(self.filtered_entries):
+            current_entry = self.filtered_entries[idx]
+            if current_entry["path"] == file_path:
+                self.update_file_info(idx)
 
     def load_root_folders(self):
-        folders = list_folders_only("KonshinHaoshin", "mygoxmujica_archive")
+        folders = list_folders_only(OWNER, REPO)
         self.folder_box.clear()
         for folder in folders:
             self.folder_box.addItem(folder["name"])
 
     def load_selected_folder_files(self):
         folder_name = self.folder_box.currentText()
-        files = list_all_files_recursive("KonshinHaoshin", "mygoxmujica_archive", folder_name)
+        self._timestamp_cache.clear()
+        files = list_all_files_recursive(OWNER, REPO, folder_name)
         self.entries = [f for f in files if f["type"] == "file"]
         self.update_list_widget(self.entries)
 
     def update_list_widget(self, entries):
-        self.list_widget.setUpdatesEnabled(False)  # 暂停刷新
-
+        self.list_widget.setUpdatesEnabled(False)
         self.list_widget.clear()
         for item in entries:
             self.list_widget.addItem(item["path"])
 
         self.filtered_entries = entries
-        self.status_label.setText(f"📄 共 {len(entries)} 个文件（含子目录）")
+        self.status_label.setText(f"共 {len(entries)} 个文件（含子目录）")
 
-        self.list_widget.setUpdatesEnabled(True)  # 恢复并强制刷新
+        self.list_widget.setUpdatesEnabled(True)
         self.list_widget.repaint()
 
     def filter_list(self, text):
@@ -255,11 +334,11 @@ class MainWindow(QMainWindow):
         relative_path = entry["path"].replace("/", os.sep)
         save_path = os.path.join(save_dir, relative_path)
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
-        mirror = self.mirror_box.currentText()
+        mirror = self.mirror_box.currentData()
 
         self.progress_bar.setRange(0, 0)
         self.progress_bar.setVisible(True)
-        self.status_label.setText(f"⬇ 正在下载: {save_path}")
+        self.status_label.setText(f"正在下载: {save_path}")
         self.stop_button.setEnabled(True)
 
         self.thread = DownloadThread(entry["download_url"], save_path, mirror)
@@ -275,7 +354,7 @@ class MainWindow(QMainWindow):
     def stop_download(self):
         if hasattr(self, 'thread') and self.thread.isRunning():
             self.thread.stop()
-            self.status_label.setText("🚩 用户已请求中止下载")
+            self.status_label.setText("用户已请求中止下载")
             self.stop_button.setEnabled(False)
 
     def on_download_finished(self, success, message):


### PR DESCRIPTION
## Summary by Sourcery

将桌面下载器的 UI 迁移到 PySide6，并新增预览相关功能、仓库元数据展示，以及持久化缓存，以提升性能和可用性。

New Features:
- 添加图片预览流程：遵循所选下载镜像源，并通过带线程的工作对话框实现加载与取消。
- 引入公告对话框：以更新通知的形式展示仓库的最近提交记录，支持后台拉取并具备优雅的错误处理。
- 在状态区域显示每个文件的上传时间戳：通过查询 GitHub API 获取并缓存结果。
- 添加可选的下载镜像列表：提供对用户友好的标签，并在主窗口、下载器和镜像选择对话框之间共享同一套键值。

Enhancements:
- 将文件列表、时间戳元数据和提交历史持久化到基于 JSON 的缓存中，加快后续加载速度并减少 API 调用。
- 通过工作线程异步加载文件夹内容及相关元数据，保持 UI 响应性，并支持在后台刷新缓存数据。
- 统一和简化面向用户的消息与状态标签：去除多余表情符号噪音，并澄清镜像描述。
- 在主界面、线程下载器和辅助函数之间对镜像处理逻辑进行统一，更新端点和默认值以优先使用 raw 与现代代理主机。
- 优化预览工作线程和对话框行为，更好地支持取消与错误报告，并避免阻塞 UI。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate the desktop downloader UI to PySide6 while adding preview-related features, repository metadata display, and persistent caching to improve performance and usability.

New Features:
- Add an image preview flow that respects the selected download mirror and uses a threaded worker dialog for loading and cancellation.
- Introduce an announcement dialog that shows recent repository commits as update notices, with background fetching and graceful error handling.
- Display per-file upload timestamps in the status area by querying the GitHub API and caching results.
- Add a selectable list of download mirrors with user-friendly labels and keys shared across the main window, downloader, and mirror selection dialog.

Enhancements:
- Persist file lists, timestamp metadata, and commit history in a JSON-backed cache to speed up subsequent loads and reduce API calls.
- Load folder contents and associated metadata asynchronously via worker threads to keep the UI responsive and allow background refresh of cached data.
- Standardize and simplify user-facing messages and status labels by removing emoji noise and clarifying mirror descriptions.
- Align mirror handling across the main UI, threaded downloader, and helper functions, updating endpoints and defaults to favor raw and modern proxy hosts.
- Refine the preview worker and dialog behavior to better support cancellation and error reporting without blocking the UI.

</details>