### PR TITLE
Add CNB image source as default and update conversion logic

### DIFF
--- a/download_thread.py
+++ b/download_thread.py
@@ -13,7 +13,7 @@ class DownloadThread(QThread):
         self.save_path = save_path
         self.mirror = mirror
         self._is_running = True
-        self.mirrors = ["raw", "jsdelivr", "ghproxy.net", "ghfast.top", "shelter"]
+        self.mirrors = ["cnb", "raw", "jsdelivr", "ghproxy.net", "ghfast.top", "shelter"]
 
     def stop(self):
         self._is_running = False
@@ -59,6 +59,12 @@ class DownloadThread(QThread):
                 "https://raw.githubusercontent.com/KonshinHaoshin/mygoxmujica_archive/main/",
                 "https://git.shelter.net.cn/Shelter/shelter_archive/raw/branch/main/"
             )
+        elif mirror == "cnb":
+            cnb_base = "https://cnb.cool/shelter.net.cn/mygoxmujica_archive/-/git/raw/main/"
+            return url.replace(
+                "https://raw.githubusercontent.com/KonshinHaoshin/mygoxmujica_archive/main/",
+                cnb_base
+            ) + "?download=true"
         elif mirror == "raw":
             return url
         return url

--- a/mirror_dialog.py
+++ b/mirror_dialog.py
@@ -1,8 +1,9 @@
-# mirror_dialog.py
+﻿# mirror_dialog.py
 from PySide6.QtWidgets import QComboBox, QDialog, QLabel, QPushButton, QVBoxLayout
 
 
 MIRRORS = [
+    ("cnb（腾讯云原生构建，优先推荐）", "cnb"),
     ("raw（直连 GitHub，实时但国内不稳定）", "raw"),
     ("jsdelivr（CDN 加速，国内稳定，有缓存延迟）", "jsdelivr"),
     ("ghproxy.net（代理加速，支持大文件）", "ghproxy.net"),

--- a/ui_main.py
+++ b/ui_main.py
@@ -246,6 +246,8 @@ class MainWindow(QMainWindow):
             url = f"https://cdn.jsdelivr.net/gh/{owner}/{repo}@{branch}/{rel_path}"
         elif mirror == "shelter":
             url = f"https://git.shelter.net.cn/Shelter/shelter_archive/raw/branch/{branch}/{rel_path}"
+        elif mirror == "cnb":
+            url = f"https://cnb.cool/shelter.net.cn/mygoxmujica_archive/-/git/raw/main/{rel_path}?download=true"
         else:
             url = raw_url
 

--- a/ui_main.py
+++ b/ui_main.py
@@ -123,7 +123,7 @@ class MainWindow(QMainWindow):
             self.setStyleSheet(f.read())
 
         self.setWindowIcon(QIcon(resource_path("icon.png")))
-        self.setWindowTitle("mygoxmujica社区资源下载器 v2.0 关注B站东山燃灯寺谢谢喵~")
+        self.setWindowTitle("mygoxmujica社区资源下载器 v2.0.1 关注B站东山燃灯寺谢谢喵~")
 
         self.folder_box = QComboBox()
         self.search_bar = QLineEdit()


### PR DESCRIPTION
## Summary by Sourcery

将 CNB 添加为新的默认镜像源，并更新相关的 URL 转换和预览逻辑。

新功能：
- 引入新的 CNB 镜像选项，基于腾讯云原生构建，用于下载和预览资源。

增强：
- 在下载器和镜像选择对话框中，将 CNB 设为默认镜像。
- 将应用程序窗口标题更新为 2.0.1 版本，以反映新版本发布。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add CNB as the new default mirror source and update related URL conversion and preview logic.

New Features:
- Introduce a new CNB mirror option backed by Tencent Cloud native build for downloading and previewing resources.

Enhancements:
- Make CNB the default mirror in the downloader and mirror selection dialog.
- Update the application window title to version 2.0.1 to reflect the new release.

</details>